### PR TITLE
FYP-46: add sunfire reports to individual projects + tweaks to dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,18 @@ jobs:
         command: mvn verify --settings 'pom.xml'
     - save_cache:
         paths:
-        - ~/.m2
+            - ~/.m2
         key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+    - run:
+        name: Save test results
+        command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+        when: always
     - store_test_results:
-        path: target/surefire-reports
+        path: ~/test-results
+    - store_artifacts:
+        path: ~/test-results/junit   
 workflows:
   maven_test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
         command: |
             mkdir -p ~/test-results/junit/
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/junit/ \;
         when: always
     - store_test_results:
         path: ~/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             mkdir -p ~/test-results/junit/
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
             find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*jar" -exec cp {} ~/test-results/junit/ \;
         when: always
     - store_test_results:
         path: ~/test-results

--- a/language-server/pom.xml
+++ b/language-server/pom.xml
@@ -11,7 +11,22 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>langserver-core</artifactId>
     <packaging>jar</packaging>
-    <dependencies>
+        <dependencies>
+            <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-symbol-solver-core</artifactId>
+            <version>3.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core-serialization</artifactId>
+            <version>3.18.0</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -32,4 +47,13 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
+        <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -19,11 +19,6 @@
             <artifactId>langserver-core</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.1</version>
-        </dependency>
     </dependencies>
     
     <build>
@@ -58,6 +53,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,21 +14,6 @@
             <version>${lsp4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-core</artifactId>
-            <version>3.18.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-symbol-solver-core</artifactId>
-            <version>3.18.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-core-serialization</artifactId>
-            <version>3.18.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.7.1</version>
@@ -54,15 +39,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
-            </plugin>
         </plugins>
     </build>
     <properties>
         <lsp4j.version>0.10.0</lsp4j.version>
+        <surefire.version>2.22.1</surefire.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>


### PR DESCRIPTION
- Sunfire reports now in launcher and lang-server, instead of in the parent project
- Moved java-parser out of the parent project and specifically to the lang-server