### PR TITLE
FYP-2: update the way we produce and display the simple AST

### DIFF
--- a/language-server/src/main/java/org/brunel/fyp/langserver/MJGAWorkspaceService.java
+++ b/language-server/src/main/java/org/brunel/fyp/langserver/MJGAWorkspaceService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.printer.DotPrinter;
 import com.github.javaparser.serialization.JavaParserJsonSerializer;
 import org.brunel.fyp.langserver.commands.Commands;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
@@ -38,8 +39,9 @@ public class MJGAWorkspaceService implements WorkspaceService {
                 String command = params.getCommand();
                 if (command.equals(Commands.REFACTOR_FILE)) {
                     return MJGALanguageServer.getInstance().getTextDocumentService().refactor(compilationUnit);
-                } else if (command.equals(Commands.GENERATE_JSON_AST)) {
-                    return this.serialise(compilationUnit);
+                } else if (command.equals(Commands.GENERATE_DOT_AST)) {
+                    DotPrinter dotPrinter = new DotPrinter(true);
+                    return dotPrinter.output(compilationUnit);
                 }
             } catch (Throwable e) {
                 LOGGER.log(Level.SEVERE, e.getMessage());

--- a/language-server/src/main/java/org/brunel/fyp/langserver/MJGAWorkspaceService.java
+++ b/language-server/src/main/java/org/brunel/fyp/langserver/MJGAWorkspaceService.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.printer.DotPrinter;
-import com.github.javaparser.serialization.JavaParserJsonSerializer;
 import org.brunel.fyp.langserver.commands.Commands;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
@@ -15,12 +13,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
-import javax.json.Json;
-import javax.json.stream.JsonGenerator;
-import javax.json.stream.JsonGeneratorFactory;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
@@ -40,7 +33,7 @@ public class MJGAWorkspaceService implements WorkspaceService {
                 if (command.equals(Commands.REFACTOR_FILE)) {
                     return MJGALanguageServer.getInstance().getTextDocumentService().refactor(compilationUnit);
                 } else if (command.equals(Commands.GENERATE_DOT_AST)) {
-                    DotPrinter dotPrinter = new DotPrinter(true);
+                    DotPrinter dotPrinter = new DotPrinter(false);
                     return dotPrinter.output(compilationUnit);
                 }
             } catch (Throwable e) {
@@ -50,17 +43,6 @@ public class MJGAWorkspaceService implements WorkspaceService {
 
             throw new UnsupportedOperationException();
         });
-    }
-
-    private String serialise(Node node) {
-        JsonGeneratorFactory generatorFactory = Json.createGeneratorFactory(new HashMap<>());
-        JavaParserJsonSerializer serializer = new JavaParserJsonSerializer();
-        StringWriter jsonWriter = new StringWriter();
-        try (JsonGenerator generator = generatorFactory.createGenerator(jsonWriter)) {
-            serializer.serialize(node, generator);
-        }
-
-        return jsonWriter.toString();
     }
 
     private CompilationUnit parseFile(String fileUri) throws IOException {

--- a/language-server/src/main/java/org/brunel/fyp/langserver/MJGAWorkspaceService.java
+++ b/language-server/src/main/java/org/brunel/fyp/langserver/MJGAWorkspaceService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.serialization.JavaParserJsonSerializer;
 import org.brunel.fyp.langserver.commands.Commands;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
@@ -12,7 +14,12 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
+import javax.json.Json;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonGeneratorFactory;
 import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
@@ -26,10 +33,13 @@ public class MJGAWorkspaceService implements WorkspaceService {
     public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                if (params.getCommand().equals(Commands.REFACTOR_FILE)) {
-                    String fileUri = params.getArguments().get(0).toString();
-                    CompilationUnit compilationUnit = this.parseFile(fileUri);
+                String fileUri = params.getArguments().get(0).toString();
+                CompilationUnit compilationUnit = this.parseFile(fileUri);
+                String command = params.getCommand();
+                if (command.equals(Commands.REFACTOR_FILE)) {
                     return MJGALanguageServer.getInstance().getTextDocumentService().refactor(compilationUnit);
+                } else if (command.equals(Commands.GENERATE_JSON_AST)) {
+                    return this.serialise(compilationUnit);
                 }
             } catch (Throwable e) {
                 LOGGER.log(Level.SEVERE, e.getMessage());
@@ -38,6 +48,17 @@ public class MJGAWorkspaceService implements WorkspaceService {
 
             throw new UnsupportedOperationException();
         });
+    }
+
+    private String serialise(Node node) {
+        JsonGeneratorFactory generatorFactory = Json.createGeneratorFactory(new HashMap<>());
+        JavaParserJsonSerializer serializer = new JavaParserJsonSerializer();
+        StringWriter jsonWriter = new StringWriter();
+        try (JsonGenerator generator = generatorFactory.createGenerator(jsonWriter)) {
+            serializer.serialize(node, generator);
+        }
+
+        return jsonWriter.toString();
     }
 
     private CompilationUnit parseFile(String fileUri) throws IOException {

--- a/language-server/src/main/java/org/brunel/fyp/langserver/commands/Commands.java
+++ b/language-server/src/main/java/org/brunel/fyp/langserver/commands/Commands.java
@@ -3,6 +3,7 @@ package org.brunel.fyp.langserver.commands;
 public class Commands {
     public static final String REFACTOR_FILE = "mjga.langserver.refactorFile";
     public static final String REFACTOR_SNIPPET = "mjga.langserver.refactorSnippet";
+    public static final String GENERATE_JSON_AST = "mjga.langserver.generateJsonAST";
 
-    public static final String[] ALL_COMMANDS = { REFACTOR_FILE, REFACTOR_SNIPPET };
+    public static final String[] ALL_COMMANDS = { REFACTOR_FILE, REFACTOR_SNIPPET, GENERATE_JSON_AST };
 }

--- a/language-server/src/main/java/org/brunel/fyp/langserver/commands/Commands.java
+++ b/language-server/src/main/java/org/brunel/fyp/langserver/commands/Commands.java
@@ -3,7 +3,7 @@ package org.brunel.fyp.langserver.commands;
 public class Commands {
     public static final String REFACTOR_FILE = "mjga.langserver.refactorFile";
     public static final String REFACTOR_SNIPPET = "mjga.langserver.refactorSnippet";
-    public static final String GENERATE_JSON_AST = "mjga.langserver.generateJsonAST";
+    public static final String GENERATE_DOT_AST = "mjga.langserver.generateDotAST";
 
-    public static final String[] ALL_COMMANDS = { REFACTOR_FILE, REFACTOR_SNIPPET, GENERATE_JSON_AST };
+    public static final String[] ALL_COMMANDS = { REFACTOR_FILE, REFACTOR_SNIPPET, GENERATE_DOT_AST};
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "watch": "tsc -watch -p ./ "
   },
   "devDependencies": {
-    "@types/flat": "^5.0.1",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.1",
     "@types/node": "^14.14.31",
@@ -46,10 +45,6 @@
     "vscode-test": "^1.5.1"
   },
   "dependencies": {
-    "deepdash": "^5.3.5",
-    "flat": "^5.0.2",
-    "mulang": "^6.0.5",
-    "path": "^0.12.7",
     "prettier": "^2.2.1",
     "prettier-plugin-java": "^1.0.1",
     "vscode-languageclient": "6.1.3"

--- a/src/commands/displaySyntaxTree.ts
+++ b/src/commands/displaySyntaxTree.ts
@@ -1,20 +1,25 @@
-import * as mulang from 'mulang';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { flatten, unflatten } from 'flat';
 import { getEditor } from '../utils';
 
-const _ = require('lodash');
-require('deepdash')(_);
-
-export function displaySyntaxTree() {
+export async function displaySyntaxTree(): Promise<void> {
   const editor = getEditor();
-  const code = editor.document.getText();
+
+  const dotAst: string =
+    (await vscode.commands.executeCommand(
+      'mjga.langserver.generateDotAST',
+      editor.document.uri.fsPath,
+    )) ?? '';
+
+  if (dotAst.length === 0) {
+    vscode.window.showInformationMessage('Error!');
+    return;
+  }
 
   // Get the last part of the filename (after the last slash), e.g. Refactor.java
   const filename = editor.document.fileName.substring(
     editor.document.fileName.lastIndexOf('/') + 1,
   );
+
   const panel = vscode.window.createWebviewPanel(
     'syntaxTreeGraph',
     `${filename} - Simple Abstract Syntax Tree`,
@@ -24,257 +29,26 @@ export function displaySyntaxTree() {
     },
   );
 
-  let ast = {
-    tag: '',
-    contents: {},
-  };
-
-  try {
-    ast = mulang.nativeCode('Java', code).ast;
-  } catch (error) {
-    throw Error(error.message);
-  }
-
-  ast = _.filterDeep(ast, (value: any, key: any, parent: any) => {
-    if (value !== null) {
-      if (Array.isArray(value) && value.length === 0) {
-        return false;
-      }
-
-      return true;
-    }
-
-    return false;
-  });
-
-  // First 'contents' is the Class name
-  ast.contents = [
-    {
-      tag: ast.contents[0],
-      contents: [ast.contents[1]],
-    },
-  ];
-
-  // Fix up the EntryPoint as well
-  ast.contents[0].contents[0].contents = [
-    {
-      tag: ast.contents[0].contents[0].contents[0],
-      contents: [ast.contents[0].contents[0].contents[1]],
-    },
-  ];
-
-  let flattenAst = flatten(ast) as object;
-  let flattedModifiedAst = {};
-  Object.keys(flattenAst).forEach((key: string) => {
-    let newKey = key;
-    let newValue = flattenAst[key];
-
-    newKey = newKey.replace(/tag/g, 'name');
-
-    if (newKey.endsWith('contents')) {
-      newValue = [newValue];
-      newKey = newKey.concat('.0');
-    }
-
-    newKey = newKey.replace(/contents/g, 'children');
-    if (flattenAst[key] === null) {
-      newValue = '';
-    }
-
-    let lastChar = newKey.substr(newKey.length - 1);
-    if (!isNaN(parseInt(lastChar))) {
-      newKey = newKey.concat('.name');
-    }
-
-    flattedModifiedAst[newKey] = newValue;
-  });
-
-  let jsonString = JSON.stringify(unflatten(flattedModifiedAst));
-  const newFile = vscode.Uri.parse(
-    'untitled:' +
-      path.join(
-        vscode.workspace.workspaceFolders!.toString(),
-        'simple-ast.json',
-      ),
-  );
-
-  vscode.workspace.openTextDocument(newFile).then((document) => {
-    const edit = new vscode.WorkspaceEdit();
-    edit.insert(newFile, new vscode.Position(0, 0), jsonString);
-    return vscode.workspace.applyEdit(edit).then((success) => {
-      if (success) {
-        vscode.window.showTextDocument(document);
-      } else {
-        vscode.window.showInformationMessage('Error!');
-      }
-    });
-  });
-
   // And set its HTML content
-  panel.webview.html = getWebviewContent(jsonString);
+  const html = getWebviewContent(dotAst);
+  panel.webview.html = html;
 }
 
 function getWebviewContent(treeData: string) {
-  return `<!DOCTYPE html>
-  <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Simple Abstract Syntax Tree</title>
-    <style>
-      .node {
-        cursor: pointer;
-      }
-      
-      .node circle {
-        stroke-width: 3px;
-      }
-      
-      .node text {
-        font: 12px sans-serif;
-        fill: #fff;
-      }
-      
-      .link {
-        fill: none;
-        stroke: #ccc;
-        stroke-width: 2px;
-      }
-      
-      .tree {
-        margin-bottom: 10px;
-        overflow: auto;
-      }
-    </style>
-  </head>
+  return `
+  <!DOCTYPE html>
+  <meta charset="utf-8">
   <body>
-    <h1>Simple Abstract Syntax Tree</div>
-    <br />
-    <div id="tree"></div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
-    <script>
-      var margin = { top: 40, right: 120, bottom: 20, left: 120 };
-      var width = window.innerWidth / 2;
-      var height = window.innerHeight;
-
-      var i = 0, duration = 750;
-      var tree = d3.layout.tree()
-          .size([height, width]);
-      var diagonal = d3.svg.diagonal()
-          .projection(function (d) { return [d.x, d.y]; });
-      var svg = d3.select("#tree").append("svg")
-          .attr("width", width + margin.right + margin.left)
-          .attr("height", height + margin.top + margin.bottom)
-          .append("g")
-          .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
-      var root = ${treeData};
-
-      update(root);
-      
-      function update(source) {
-        // Compute the new tree layout.
-        var nodes = tree.nodes(root).reverse(),
-            links = tree.links(nodes);
-        // Normalize for fixed-depth.
-        nodes.forEach(function (d) { d.y = d.depth * 100; });
-        // Declare the nodes…
-        var node = svg.selectAll("g.node")
-            .data(nodes, function (d) { return d.id || (d.id = ++i); });
-        // Enter the nodes.
-        var nodeEnter = node.enter().append("g")
-            .attr("class", "node")
-            .attr("transform", function (d) {
-                return "translate(" + source.x0 + "," + source.y0 + ")";
-            }).on("click", nodeclick);
-        nodeEnter.append("circle")
-        .attr("r", 10)
-            .attr("stroke", function (d)
-            { return d.children || d._children ?
-            "steelblue" : "#00c13f"; })
-            .style("fill", function (d)
-            { return d.children || d._children ?
-            "lightsteelblue" : "#fff"; });
-        //.attr("r", 10)
-        //.style("fill", "#fff");
-        nodeEnter.append("text")
-            .attr("y", function (d) {
-                return d.children || d._children ? -18 : 18;
-            })
-            .attr("dy", ".35em")
-            .attr("text-anchor", "middle")
-            .text(function (d) { return d.name; })
-            .style("fill-opacity", 1e-6);
-        // Transition nodes to their new position.
-        //horizontal tree
-        var nodeUpdate = node.transition()
-            .duration(duration)
-            .attr("transform", function (d)
-            { return "translate(" + d.x +
-            "," + d.y + ")"; });
-        nodeUpdate.select("circle")
-            .attr("r", 10)
-            .style("fill", function (d)
-            { return d._children ? "lightsteelblue" : "#fff"; });
-        nodeUpdate.select("text")
-            .style("fill-opacity", 1);
-
-        // Transition exiting nodes to the parent's new position.
-        var nodeExit = node.exit().transition()
-            .duration(duration)
-            .attr("transform", function (d)
-            { return "translate(" + source.x +
-            "," + source.y + ")"; })
-            .remove();
-        nodeExit.select("circle")
-            .attr("r", 1e-6);
-        nodeExit.select("text")
-            .style("fill-opacity", 1e-6);
-        // Update the links…
-        // Declare the links…
-        var link = svg.selectAll("path.link")
-            .data(links, function (d) { return d.target.id; });
-        // Enter the links.
-        link.enter().insert("path", "g")
-            .attr("class", "link")
-
-            .attr("d", function (d) {
-                var o = { x: source.x0, y: source.y0 };
-                return diagonal({ source: o, target: o });
-            });
-        // Transition links to their new position.
-        link.transition()
-            .duration(duration)
-        .attr("d", diagonal);
-
-        // Transition exiting nodes to the parent's new position.
-        link.exit().transition()
-            .duration(duration)
-            .attr("d", function (d) {
-                var o = { x: source.x, y: source.y };
-                return diagonal({ source: o, target: o });
-            })
-            .remove();
-
-        // Stash the old positions for transition.
-        nodes.forEach(function (d) {
-            d.x0 = d.x;
-            d.y0 = d.y;
-        });
-      }
-
-      // Toggle children on click.
-      function nodeclick(d) {
-        if (d.children) {
-            d._children = d.children;
-            d.children = null;
-        } else {
-            d.children = d._children;
-            d._children = null;
-        }
-        update(d);
-      }
-
+    <script src="https://d3js.org/d3.v6.min.js"></script>
+    <script src="https://unpkg.com/@hpcc-js/wasm@0.3.11/dist/index.min.js"></script>
+    <script src="https://unpkg.com/d3-graphviz@3.0.5/build/d3-graphviz.js"></script>
+    <h1>Simple Abstract Syntax Tree</h1>
+    <div id="graph" style="text-align: center;"></div>
+    <script>  
+    d3.select("#graph")
+      .graphviz()
+      .renderDot(\`${treeData}\`);
     </script>
-  </body>
-  </html>`;
+  <body>
+  `;
 }

--- a/src/commands/displaySyntaxTree.ts
+++ b/src/commands/displaySyntaxTree.ts
@@ -39,16 +39,71 @@ function getWebviewContent(treeData: string) {
   <!DOCTYPE html>
   <meta charset="utf-8">
   <body>
-    <script src="https://d3js.org/d3.v6.min.js"></script>
+    <script src="https://d3js.org/d3.v5.min.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm@0.3.11/dist/index.min.js"></script>
     <script src="https://unpkg.com/d3-graphviz@3.0.5/build/d3-graphviz.js"></script>
     <h1>Simple Abstract Syntax Tree</h1>
     <div id="graph" style="text-align: center;"></div>
-    <script>  
-    d3.select("#graph")
-      .graphviz()
-      .renderDot(\`${treeData}\`);
+    <script>
+      // to avoid scrollbars
+      var margin = 20;
+      
+      var graphviz = d3.select("#graph").graphviz()
+      .attributer(attributer)
+          .logEvents(true)
+          .on("initEnd", render);
+      
+          function attributer(datum, index, nodes) {
+          var selection = d3.select(this);
+          if (datum.tag == "svg") {
+              var width = window.innerWidth;
+              var height = window.innerHeight;
+              selection
+                  .attr("width", width)
+                  .attr("height", height)
+              datum.attributes.width = width - margin;
+              datum.attributes.height = height - margin;
+          }
+      }
+      
+      function render() {
+          graphviz
+          .renderDot(\`${treeData}\`)
+          .zoom(true);
+      }
+      
+      function attributer(datum, index, nodes) {
+          var selection = d3.select(this);
+          if (datum.tag == "svg") {
+              var width = window.innerWidth;
+              var height = window.innerHeight;
+              selection
+                  .attr("width", width)
+                  .attr("height", height)
+              datum.attributes.width = width - margin;
+              datum.attributes.height = height - margin;
+          }
+      }
+      
+      function resetZoom() {
+          graphviz
+              .resetZoom(d3.transition().duration(1000));
+      }
+      
+      function resizeSVG() {
+          console.log('Resize');
+          var width = window.innerWidth;
+          var height = window.innerHeight;
+          d3.select("#graph").selectWithoutDataPropagation("svg")
+              .transition()
+              .duration(700)
+              .attr("width", width - margin)
+              .attr("height", height - margin);
+      };
+      
+      d3.select(window).on("resize", resizeSVG);
+      d3.select(window).on("click", resetZoom);
     </script>
-  <body>
+    <body>
   `;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,11 +64,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/flat@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@types/flat/-/flat-5.0.1.tgz#9d703bbfb59ad9ec9ce376bdeb93a0f85da27059"
-  integrity sha512-ykRODHi9G9exJdTZvQggsqCUtB7jqiwLHcXCjNMb7zgWx6Lc2bydIUYBG1+It6VXZVFaeROv6HqPjDCAsoPG3w==
-
 "@types/glob@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -450,14 +445,6 @@ deep-is@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-
-deepdash@^5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/deepdash/-/deepdash-5.3.5.tgz#611bec9c1f2829832d21971dcbefe712e408647d"
-  integrity sha512-1ZdPPCI1pCEqeAWGSw+Nbpb/2iIV4w3sGPc22H/PDtcApb8+psTzPIoOVD040iBaT2wqZab29Kjrz6G+cd5mqQ==
-  dependencies:
-    lodash "^4.17.20"
-    lodash-es "^4.17.20"
 
 diff@5.0.0:
   version "5.0.0"
@@ -860,11 +847,6 @@ inherits@2, inherits@~2.0.0, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -972,11 +954,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
-  integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
-
 lodash@4.17.20, lodash@^4.17.15, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -1069,11 +1046,6 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mulang@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/mulang/-/mulang-6.0.5.tgz#1b6a167bbf64b3de815d7993bbf1c8ed931136a1"
-  integrity sha512-iBSjKYVb1QbaQTJtKrZ3gnCn768Qq0EWEokQJL+qlNj6SGWZtTPM9vkk8+u7vrV5+K+zZVugO/y5X5MRL+ZBeg==
-
 nanoid@3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
@@ -1149,14 +1121,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-path@^0.12.7:
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
-  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
-  dependencies:
-    process "^0.11.1"
-    util "^0.10.3"
-
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -1192,11 +1156,6 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-process@^0.11.1:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^2.0.0:
   version "2.0.3"
@@ -1505,13 +1464,6 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"


### PR DESCRIPTION
Since we moved to use `JavaParser` we need to change the way generate and display the AST.

- Added new command sent to Language Server, which returns us a DOT (graph description language) of the AST
- We use D3.js to display that Dot graph
- Removed unnecessary Node packages